### PR TITLE
Treat "something went wrong" GraphQL errors as status 500.

### DIFF
--- a/hubkit.js
+++ b/hubkit.js
@@ -282,6 +282,9 @@ if (typeof require !== 'undefined') {
               else if (res.data.errors.every(function(error) {
                 return error.type === 'NOT_FOUND';
               })) status = 404;
+              else if (res.data.errors.some(function(error) {
+                return /^something went wrong/i.test(error.message);
+              })) status = 500;
               else status = 400;
             }
             if (status === 404 && typeof options.ifNotFound !== 'undefined') {


### PR DESCRIPTION
These errors don't include an error code and were treated as status 400 by default, but it's more useful to think of them as 500's instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/hubkit/15)
<!-- Reviewable:end -->
