### PR TITLE
Fail if apparently-paginated GraphQL queries lack a `pageInfo` structure.

### DIFF
--- a/hubkit.js
+++ b/hubkit.js
@@ -352,8 +352,14 @@ if (typeof require !== 'undefined') {
                   root = root[keys[0]];
                   if (root && root.nodes) break;
                 }
-                const paginated = root && Array.isArray(root.nodes) && root.pageInfo &&
+                const paginated = root && Array.isArray(root.nodes) &&
                   /^\s*query[^({]*\((|[^)]*[(,\s])\$after\s*:\s*String[),\s]/.test(options.body.query);
+                if (paginated && !(
+                  root.pageInfo && 'endCursor' in root.pageInfo && 'hasNextPage' in root.pageInfo
+                )) {
+                  throw new Error(
+                    `Internal error: paginated query missing pageInfo at ${rootKeys.join('.')}`);
+                }
                 let resultRoot;
                 if (paginated) {
                   resultRoot = result;


### PR DESCRIPTION
This is almost certainly a bug — I can't think of a legitimate situation where all the other conditions pass but we don't actually intend to paginate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/hubkit/34)
<!-- Reviewable:end -->
